### PR TITLE
Dlt guide update 1

### DIFF
--- a/python/DLT Event Log Queries.py
+++ b/python/DLT Event Log Queries.py
@@ -4,12 +4,26 @@
 
 # COMMAND ----------
 
-# Fill in the pipelines_id and pipeline_name
-pipelines_id = "c4885e65-0eca-4d87-9c38-88a7840c5f8b"
-pipeline_name = "Wikipedia Python Pipeline"
+# Fill in the pipelines_id, pipeline_name and storage_location
+pipelines_id = "" #used to find the event path if storage location is blank
+pipeline_name = "" 
+storage_location = "" #may be blank, in which case, the pipelines_id is used for the event path
 
 from pyspark.sql.functions import *
 from pyspark.sql.types import *
+
+# COMMAND ----------
+
+# derive event location based on storage_location and pipelines_id
+
+event_location = ""
+
+if storage_location != "":
+  event_location = "dbfs:" + storage_location + "/system/events/"
+else:
+  event_location = "dbfs:/pipelines/" + pipelines_id + "/system/events/"
+  
+event_location
 
 # COMMAND ----------
 

--- a/python/DLT Event Log Queries.py
+++ b/python/DLT Event Log Queries.py
@@ -33,7 +33,7 @@ event_location
 
 # Data Quality Expecations | Flow Progress Completed
 sqlQuery = """SELECT id, origin, timestamp, details
-                FROM delta.`dbfs:/pipelines/""" + pipelines_id + """/system/events/`
+                FROM delta.`""" + event_location + """`
                WHERE details LIKE '%flow_progress%COMPLETED%data_quality%expectations%' order by timestamp desc"""
 df = spark.sql(sqlQuery)
 
@@ -68,9 +68,9 @@ df_expectations.createOrReplaceTempView("df_expectations")
 
 # DLT Lineage (skip maintenance jobs)
 sqlQuery = """SELECT id, origin, sequence, timestamp, message, event_type, details
-                FROM delta.`dbfs:/pipelines/""" + pipelines_id + """/system/events/`
+                FROM delta.`""" + event_location + """`
                WHERE origin.cluster_id = (
-                 SELECT origin.cluster_id FROM delta.`dbfs:/pipelines/""" + pipelines_id + """/system/events/`
+                 SELECT origin.cluster_id FROM delta.`""" + event_location + """`
                   WHERE origin.pipeline_name = '""" + pipeline_name + """'
                     AND origin.maintenance_id IS NULL ORDER BY timestamp DESC LIMIT 1
                )"""

--- a/sql/Retail Sales.sql
+++ b/sql/Retail Sales.sql
@@ -2,7 +2,7 @@
 CREATE INCREMENTAL LIVE TABLE customers
 COMMENT "The customers buying finished products, ingested from /databricks-datasets."
 TBLPROPERTIES ("quality" = "mapping")
-AS SELECT * FROM cloud_files("/databricks-datasets/retail-org/customers/", "csv")
+AS SELECT * FROM cloud_files("/databricks-datasets/retail-org/customers/", "csv");
 
 -- COMMAND ----------
 
@@ -10,22 +10,23 @@ CREATE INCREMENTAL LIVE TABLE sales_orders_raw
 COMMENT "The raw sales orders, ingested from /databricks-datasets."
 TBLPROPERTIES ("quality" = "bronze")
 AS
---SELECT * FROM cloud_files("/databricks-datasets/retail-org/sales_stream/sales_stream.json/", "json", map("cloudFiles.inferColumnTypes", "true"))
 SELECT * FROM cloud_files("/databricks-datasets/retail-org/sales_orders/", "json", map("cloudFiles.inferColumnTypes", "true"))
 
 -- COMMAND ----------
 
-CREATE LIVE TABLE sales_orders_cleaned(
+CREATE INCREMENTAL LIVE TABLE sales_orders_cleaned(
   CONSTRAINT valid_order_number EXPECT (order_number IS NOT NULL) ON VIOLATION DROP ROW
 )
-PARTITIONED BY (order_datetime)
+PARTITIONED BY (order_date)
 COMMENT "The cleaned sales orders with valid order_number(s) and partitioned by order_datetime."
 TBLPROPERTIES ("quality" = "silver")
 AS
-SELECT f.customer_id, f.customer_name, f.number_of_line_items, f.order_datetime, f.order_number, f.ordered_products,
-       c.state, c.city, c.lon, c.lat, c.units_purchased, c.loyalty_segment
-  FROM LIVE.sales_orders_raw f
-    LEFT JOIN LIVE.customers c
+SELECT f.customer_id, f.customer_name, f.number_of_line_items, 
+  TIMESTAMP(from_unixtime((cast(f.order_datetime as long)))) as order_datetime, 
+  DATE(from_unixtime((cast(f.order_datetime as long)))) as order_date, 
+  f.order_number, f.ordered_products, c.state, c.city, c.lon, c.lat, c.units_purchased, c.loyalty_segment
+  FROM STREAM(LIVE.sales_orders_raw) f
+  LEFT JOIN LIVE.customers c
       ON c.customer_id = f.customer_id
      AND c.customer_name = f.customer_name
 
@@ -35,7 +36,13 @@ CREATE LIVE TABLE sales_order_in_la
 COMMENT "Sales orders in LA."
 TBLPROPERTIES ("quality" = "gold")
 AS
-SELECT * FROM LIVE.sales_orders_cleaned WHERE city = 'Los Angeles'
+SELECT city, order_date, customer_id, customer_name, ordered_products_explode.curr, SUM(ordered_products_explode.price) as sales, SUM(ordered_products_explode.qty) as qantity, COUNT(ordered_products_explode.id) as product_count
+FROM (
+  SELECT city, DATE(order_datetime) as order_date, customer_id, customer_name, EXPLODE(ordered_products) as ordered_products_explode
+  FROM LIVE.sales_orders_cleaned 
+  WHERE city = 'Los Angeles'
+  )
+GROUP BY order_date, city, customer_id, customer_name, ordered_products_explode.curr
 
 -- COMMAND ----------
 
@@ -43,4 +50,10 @@ CREATE LIVE TABLE sales_order_in_chicago
 COMMENT "Sales orders in Chicago."
 TBLPROPERTIES ("quality" = "gold")
 AS
-SELECT * FROM LIVE.sales_orders_cleaned WHERE city = 'Chicago'
+SELECT city, order_date, customer_id, customer_name, ordered_products_explode.curr, SUM(ordered_products_explode.price) as sales, SUM(ordered_products_explode.qty) as qantity, COUNT(ordered_products_explode.id) as product_count
+FROM (
+  SELECT city, DATE(order_datetime) as order_date, customer_id, customer_name, EXPLODE(ordered_products) as ordered_products_explode
+  FROM LIVE.sales_orders_cleaned 
+  WHERE city = 'Chicago'
+  )
+GROUP BY order_date, city, customer_id, customer_name, ordered_products_explode.curr


### PR DESCRIPTION
Updated Retail Sales.sql to have aggregate gold tables based on date.

Updated DLT Event Log Queries.py to be able to use a storage location instead of pipelines_id if needed